### PR TITLE
Implement Predicate querying instead of the bidder - broker flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 Cargo.lock
-methods/guest/Cargo.lock
+methods/guests/bid_verifier/Cargo.lock
 target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 members = ["host", "methods"]
 
-# Always optimize; building and running the guest takes much longer without optimization.
+# Always optimize; building and running the guests takes much longer without optimization.
 [profile.dev]
 opt-level = 3
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
-# Enhanced Privacy in Real Estate Transactions with RISC Zero zkVM and Verifiable Credentials
+# ZK Credential
 
-This is a project for the [ZK Hack Istanbul](https://www.zkistanbul.com/) hackathon.
+This is my submission for [ZK Hack Istanbul](https://www.zkistanbul.com/) hackathon. The project is a proof of concept.
 
-Thank you to the [RISC Zero](https://dev.risczero.com/) team for their support and guidance throughout the hackathon. 
-
-Also, thank you to the [ZK Hack](https://zkhack.dev/) team for organizing this event. It was a great experience!
+ZK Credential is a project that explores the use of Verifiable Credentials in maintaining privacy leveraging Zero-Knowledge Proofs (ZKP) in real-world scenarios.
 
 ## Quick Start
 
-The host program reads the `data.json` file and passes the data to the guest.
-This is where bid_size is set. You can change this to see if the program fails is set above the loan amount.
+The host program reads mock data from `data.json` file and passes the data to the guests.
 
 First, make sure [rustup](https://rustup.rs/) is installed. The
 [`rust-toolchain.toml`][rust-toolchain] file will be used by `cargo` to
@@ -33,23 +30,23 @@ cargo run
 
 ## Overview
 
-
-This project harnesses the power of RISC Zero's zkVM to demonstrate an enhanced privacy application in real estate
-transactions.
-It specifically explores the utilization of Verifiable Credentials from eIDAS 2.0 for EU citizens, showcasing how these
-credentials
-can be used in a more private manner through Zero-Knowledge Proofs (ZKP) in real-world scenarios.
-
-## Objectives
-
-- To demonstrate the effective use of RISC Zero's zkVM in privacy-centric applications.
-- To explore the application of Verifiable Credentials in maintaining privacy in financial transactions.
-- To investigate the potential of eIDAS 2.0 Verifiable Credentials in enhancing privacy for EU citizens, particularly in
-  hiding sensitive information like maximum bid amounts in real estate bidding and social security numbers in other use
-  cases.
+ZK Credential explores the utilization of Verifiable Credentials from eIDAS 2.0 for EU citizens, showcasing how these
+credentials can be used to hide sensitive information like maximum bid amounts in real estate bidding and social
+security numbers in other use cases.
 
 ## Implementation
 
+I have created two programs(guests):
+
+1. Make a bid to a broker. Check if the bid is less than the maximum amount allowed by the bank. 
+2. Generalize the program to accept any Verifiable Credential - This is a proof of concept to show how the program can
+   be generalized to accept any Verifiable Credential and validate against a given Predicate:
+    - GT - Greater than
+    - LT - Less than
+    - EQ - Equal to
+    - More to come...
+
+### 1. Make a bid to a broker
 
 ![Flow](./assets/flow.png)
 
@@ -61,9 +58,9 @@ The application employs two key Verifiable Credentials:
    granted privilege.
    These credentials are signed by respective issuers and authenticated by the user.
 
-## Core Process:
+#### Core Process:
 
-1. Credential Submission: Users submit signed JWTs for PersonCredential and HouseLoanCredential.
+1. Credential Submission: Bid size, PersonCredential and HouseLoanCredential.
 2. The RISC Zero zkVM runs the guest code, which performs the following checks:
     - Validation of JWT signatures and data.
     - Comparison of the bid size with the loan amount. If the bid exceeds the loan amount, the process fails.
@@ -71,18 +68,25 @@ The application employs two key Verifiable Credentials:
     - A Receipt with a cryptographic seal.
     - A Journal containing the public output, accessible via receipt.journal.
 
+### 2. Generalize the program to accept any Verifiable Credential
+
+#### Core Process:
+
+1. Use of any Verifiable Credential: E.g. PersonCredential and a Predicate like GT, LT, EQ. and the name of the field
+   to compare.
+
+```
+   let predicate = Predicate{
+        field: String::from_str("date_of_birth").unwrap(),
+        condition: GT,
+        value: 19791001
+    };
+```
+
 ## Technology Stack
 
 [RISC Zero zkVM](https://dev.risczero.com/)
-[Verifiable Credentials](https://www.w3.org/TR/vc-data-model/) - All citizens will have a digital wallet that contains
-their credentials from 2026/2027.
-
-## Key Features
-
-* Enhanced Privacy: Employs ZKP to verify transactions without exposing sensitive personal and financial details.
-* Secure Transaction Validation: Ensures financial integrity by validating bid amounts against pre-approved loans.
-* Versatile Application: Demonstrates the potential of Verifiable Credentials with ZK beyond real estate, such as
-  providing proof of age without revealing full social security numbers.
+[Verifiable Credentials](https://www.w3.org/TR/vc-data-model/) 
 
 ## Running proofs remotely on Bonsai
 
@@ -114,10 +118,15 @@ zkc
 └── methods
     ├── Cargo.toml
     ├── build.rs
-    ├── guest
-    │   ├── Cargo.toml
-    │   └── src
-    │       └── main.rs                   <-- [Guest code for house bid, jwt validation, etc.]
+    ├── guests
+    │   ├── bid_verifier
+    │       ├── Cargo.toml
+    │       └── src
+    │           └── main.rs                   <-- [Guest code for house bid, jwt validation, etc.]
+    │   └── predicate_verifier
+    │       ├── Cargo.toml
+    │       └── src
+    │           └── main.rs                   <-- [Guest code for predicate validation, jwt validation, etc.]
     └── src
         └── lib.rs
 ```

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ ZK Credential is a project that explores the use of Verifiable Credentials in ma
 
 The host program reads mock data from `data.json` file and passes the data to the guests.
 
-First, make sure [rustup](https://rustup.rs/) is installed. The
+1. First, make sure [rustup](https://rustup.rs/) is installed. The
 [`rust-toolchain.toml`][rust-toolchain] file will be used by `cargo` to
 automatically install the correct version.
+
+2. Install [Risc Zero Toolchain](https://dev.risczero.com/api/zkvm/quickstart#1-install-the-risc-zero-toolchain)
 
 To build all methods and execute the method within the zkVM, run the following
 command:

--- a/data.json
+++ b/data.json
@@ -1,23 +1,23 @@
 {
   "bidSize": 90000,
   "eidIssuer": {
-    "public_key": "08a7afd90669185118473b0c32b131e4ec117640baee540b9c743a782bb6b61e"
+    "public_key": "777b2f5c9a1a0e52947c406a30ebadc951cca14f3e6a0f25b5306c36c1159c91"
   },
   "bank": {
-    "public_key": "fd7042c505b5a4f047909da8d4c6c344b25a29f233f2201639445568617a6445"
+    "public_key": "80b7a5472f8b79c011eecaf8115ea93b81494e7cfbc670e397ee705cac20ec2e"
   },
   "person": {
-    "public_key": "5a2de976cf11503f2e6b670e2e12e0fe9f3b014eb615416b8ed0ac401811fbfd"
+    "public_key": "721ebd125312884b5ce4a047263e04d48631624fc32058318c577ab269be9d9c"
   },
   "personCredential": {
     "credentialSubject": {
       "name": "Bob Bobley",
-      "date_of_birth": "1980-10-01",
+      "date_of_birth": 19801001,
       "nationality": "NO",
-      "id": "did:key:z6MkkXHLrJ3bpDinQ736dvfBqt1AQhdqECbEkfmm7UHMyTCQ"
+      "id": "did:key:z6Mkn8ji3BqfuiDdcSQ9PXgnZEB1DWoEY19YX3hHNkYxcc1h"
     },
     "issuer": {
-      "id": "did:key:z6Mkf33cM15mFcLdi7fBwV8yKDu8o7LQSTHbaPzJaDWSWogR"
+      "id": "did:key:z6MknVfWMf9etYYB2XQ5iq4vNwVPBvhewsG4Mu4KG5q1Hhc4"
     },
     "type": [
       "VerifiableCredential",
@@ -26,10 +26,10 @@
     "@context": [
       "https://www.w3.org/2018/credentials/v1"
     ],
-    "issuanceDate": "2023-11-11T20:37:55.000Z",
+    "issuanceDate": "2023-11-20T19:49:29.000Z",
     "proof": {
       "type": "JwtProof2020",
-      "jwt": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiUGVyc29uQ3JlZGVudGlhbCJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJuYW1lIjoiQm9iIEJvYmxleSIsImRhdGVfb2ZfYmlydGgiOiIxOTgwLTEwLTAxIiwibmF0aW9uYWxpdHkiOiJOTyJ9fSwic3ViIjoiZGlkOmtleTp6Nk1ra1hITHJKM2JwRGluUTczNmR2ZkJxdDFBUWhkcUVDYkVrZm1tN1VITXlUQ1EiLCJuYmYiOjE2OTk3MzUwNzUsImlzcyI6ImRpZDprZXk6ejZNa2YzM2NNMTVtRmNMZGk3ZkJ3Vjh5S0R1OG83TFFTVEhiYVB6SmFEV1NXb2dSIn0.ruDArqFrsNLm119AxflJgmOaztogxyF7hMFnFJ8NfoY2aq2fQeMY5gDgKrC4-9_XT8DKYPUm8TXI90QVF9XEBw"
+      "jwt": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiUGVyc29uQ3JlZGVudGlhbCJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJuYW1lIjoiQm9iIEJvYmxleSIsImRhdGVfb2ZfYmlydGgiOjE5ODAxMDAxLCJuYXRpb25hbGl0eSI6Ik5PIn19LCJzdWIiOiJkaWQ6a2V5Ono2TWtuOGppM0JxZnVpRGRjU1E5UFhnblpFQjFEV29FWTE5WVgzaEhOa1l4Y2MxaCIsIm5iZiI6MTcwMDUwOTc2OSwiaXNzIjoiZGlkOmtleTp6Nk1rblZmV01mOWV0WVlCMlhRNWlxNHZOd1ZQQnZoZXdzRzRNdTRLRzVxMUhoYzQifQ.7c6sPZHwc-UZO2OlDv7_ttNLfnx9cBlvMYyAVXLryx_TTaleohTdaEqYmdpoM1tz3l2IVodWnnLOeDLRMVp6Aw"
     }
   },
   "houseLoanCredential": {
@@ -37,10 +37,10 @@
       "loan_amount": 1000000,
       "loan_purpose": "house purchase",
       "expiration_date": "2023-11-18",
-      "id": "did:key:z6MkkXHLrJ3bpDinQ736dvfBqt1AQhdqECbEkfmm7UHMyTCQ"
+      "id": "did:key:z6Mkn8ji3BqfuiDdcSQ9PXgnZEB1DWoEY19YX3hHNkYxcc1h"
     },
     "issuer": {
-      "id": "did:key:z6MkwWaUd3uHZchEqcFzFKD2Qy5CTrJdTx6pnXEAdc2B2nDJ"
+      "id": "did:key:z6Mko7ieXpH2JDCfBc9MijYSLz8LofTtuFoEs9i2rQfrsvNR"
     },
     "type": [
       "VerifiableCredential",
@@ -49,10 +49,10 @@
     "@context": [
       "https://www.w3.org/2018/credentials/v1"
     ],
-    "issuanceDate": "2023-11-11T20:37:55.000Z",
+    "issuanceDate": "2023-11-20T19:49:29.000Z",
     "proof": {
       "type": "JwtProof2020",
-      "jwt": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiSG91c2VMb2FuQ3JlZGVudGlhbCJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJsb2FuX2Ftb3VudCI6MTAwMDAwMCwibG9hbl9wdXJwb3NlIjoiaG91c2UgcHVyY2hhc2UiLCJleHBpcmF0aW9uX2RhdGUiOiIyMDIzLTExLTE4In19LCJzdWIiOiJkaWQ6a2V5Ono2TWtrWEhMckozYnBEaW5RNzM2ZHZmQnF0MUFRaGRxRUNiRWtmbW03VUhNeVRDUSIsIm5iZiI6MTY5OTczNTA3NSwiaXNzIjoiZGlkOmtleTp6Nk1rd1dhVWQzdUhaY2hFcWNGekZLRDJReTVDVHJKZFR4NnBuWEVBZGMyQjJuREoifQ.bftL5w-4JRKxvIg-5mFE9G305sHPzaSWng-VggTFmKPgXtJytj8XNFtGWh3bkCx1gAj2kdy5y7lMERwdgCv7Cw"
+      "jwt": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiSG91c2VMb2FuQ3JlZGVudGlhbCJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJsb2FuX2Ftb3VudCI6MTAwMDAwMCwibG9hbl9wdXJwb3NlIjoiaG91c2UgcHVyY2hhc2UiLCJleHBpcmF0aW9uX2RhdGUiOiIyMDIzLTExLTE4In19LCJzdWIiOiJkaWQ6a2V5Ono2TWtuOGppM0JxZnVpRGRjU1E5UFhnblpFQjFEV29FWTE5WVgzaEhOa1l4Y2MxaCIsIm5iZiI6MTcwMDUwOTc2OSwiaXNzIjoiZGlkOmtleTp6Nk1rbzdpZVhwSDJKRENmQmM5TWlqWVNMejhMb2ZUdHVGb0VzOWkyclFmcnN2TlIifQ.e3esT3D0TsvH_DDpbPVTrSKVLYzKvsoUfVYP6q5yULwjgqfGHOBc32ivD4zBChPPbHAJ1AwkguWe0ZsW14XBAg"
     }
   }
 }

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -3,8 +3,10 @@
 use risc0_zkvm::{default_prover, ExecutorEnv, Receipt};
 use serde::{Deserialize, Serialize};
 use std::fs;
+use std::str::FromStr;
 
-use methods::{JWT_VERIFY_ELF, JWT_VERIFY_ID};
+use methods::{BID_VERIFIER_ELF, BID_VERIFIER_ID, PREDICATE_VERIFIER_ELF, PREDICATE_VERIFIER_ID};
+use crate::Condition::{GT, LT};
 
 #[derive(Serialize, Deserialize, Debug)]
 struct PublicKeyHolder {
@@ -47,6 +49,40 @@ struct Root {
     house_loan_credential: Credential,
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+enum Condition {
+    LT,
+    GT,
+    EQ,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Predicate {
+    field: String,
+    condition: Condition,
+    value: u32
+}
+
+
+fn prove_predicate(
+    jwt: &str,
+    public_key_issuer: &str,
+    predicate: Predicate
+) -> Receipt {
+
+    let input = (jwt, public_key_issuer, predicate);
+    let env = ExecutorEnv::builder()
+        .write(&input)
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let prover = default_prover();
+
+    // Produce a receipt by proving the specified ELF binary.
+    prover.prove_elf(env, PREDICATE_VERIFIER_ELF).unwrap()
+}
+
 fn prove_valid_bid(
     bid_size: u32,
     person_credential_jwt: &str,
@@ -54,6 +90,7 @@ fn prove_valid_bid(
     eid_issuer_public_key: &str,
     bank_public_key: &str,
 ) -> Receipt {
+
     let input = (bid_size, person_credential_jwt, house_loan_credential_jwt, eid_issuer_public_key, bank_public_key);
     let env = ExecutorEnv::builder()
         .write(&input)
@@ -65,7 +102,7 @@ fn prove_valid_bid(
     let prover = default_prover();
 
     // Produce a receipt by proving the specified ELF binary.
-    prover.prove_elf(env, JWT_VERIFY_ELF).unwrap()
+    prover.prove_elf(env, BID_VERIFIER_ELF).unwrap()
 }
 
 fn main() {
@@ -74,6 +111,36 @@ fn main() {
 
     // read json file from current directory
     let data = fs::read_to_string("./data.json").expect("Unable to read file");
+    // verify_bid_program(&data);
+    verify_predicate_program(&data);
+}
+
+fn verify_predicate_program(data: &String) {
+    let root: Root = serde_json::from_str(&data).expect("JSON was not well-formatted");
+
+    let person_credential = root.person_credential;
+
+    let predicate = Predicate{
+        field: String::from_str("date_of_birth").unwrap(),
+        condition: GT,
+        value: 19791001
+    };
+
+    let public_key_eid = root.eid_issuer.public_key;
+
+    let receipt = prove_predicate(&person_credential.proof.jwt, &public_key_eid, predicate);
+
+    let valid: bool = receipt.journal.decode().unwrap();
+    receipt.verify(PREDICATE_VERIFIER_ID).unwrap();
+
+    println!("\n");
+    println!("Verification results:");
+    println!("\n");
+    println!("{:<30} {}", "Verification status:", if valid { "Verified ✅" } else { "Failed ❌" });
+
+}
+
+fn verify_bid_program(data: &String) {
 
     let root: Root = serde_json::from_str(&data).expect("JSON was not well-formatted");
 
@@ -85,9 +152,15 @@ fn main() {
     let person_credential = root.person_credential;
     let house_loan_credential = root.house_loan_credential;
 
-    let receipt = prove_valid_bid(bid_size, &person_credential.proof.jwt, &house_loan_credential.proof.jwt, &public_key_eid, &public_key_bank);
+    let receipt = prove_valid_bid(
+        bid_size,
+        &person_credential.proof.jwt,
+        &house_loan_credential.proof.jwt,
+        &public_key_eid,
+        &public_key_bank
+    );
     let (is_valid_bid, bidder_did, bid_size): (u32, String, u32) = receipt.journal.decode().unwrap();
-    receipt.verify(JWT_VERIFY_ID).unwrap();
+    receipt.verify(BID_VERIFIER_ID).unwrap();
 
     // print two empty lines
     println!("\n");
@@ -99,5 +172,4 @@ fn main() {
     println!("{:<30} {}", "Bid status:", if is_valid_bid != 0 { "Valid ✅" } else { "Invalid ❌" });
     println!("{:<30} {}", "Bidder DID:", bidder_did);
     println!("\n");
-
 }

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -137,6 +137,7 @@ fn verify_predicate_program(data: &String) {
     println!("Verification results:");
     println!("\n");
     println!("{:<30} {}", "Verification status:", if valid { "Verified ✅" } else { "Failed ❌" });
+    println!("\n");
 
 }
 

--- a/methods/Cargo.toml
+++ b/methods/Cargo.toml
@@ -9,13 +9,14 @@ anyhow = "1.0"
 clap = "4.4"
 k256 = { version = "0.13", features = ["serde"] }
 rand_core = "0.6.4"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [build-dependencies]
 risc0-build = { version = "0.19.1" }
 
 [package.metadata.risc0]
-methods = ["guest"]
+methods = ["guests/bid_verifier", "guests/predicate_verifier"]
 
 [features]
 default = []

--- a/methods/guests/bid_verifier/Cargo.toml
+++ b/methods/guests/bid_verifier/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bid_verifier"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[dependencies]
+serde = "1.0"
+serde_json = "1.0"
+risc0-zkvm = { version = "0.19.1", default-features = false, features = ["std"] }
+hex = "0.4.3"
+k256 = { version = "=0.13.1", features = ["arithmetic", "serde", "expose-field", "std", "ecdsa"], default_features = false }
+jwt-compact = { version = "0.8.0", features = ["ed25519-dalek"] }
+ed25519-dalek = "2.0.0"
+
+[profile.release]
+lto = "thin"

--- a/methods/guests/bid_verifier/src/main.rs
+++ b/methods/guests/bid_verifier/src/main.rs
@@ -2,11 +2,26 @@
 
 use ed25519_dalek::VerifyingKey;
 use jwt_compact::{alg::*, prelude::*, Token, UntrustedToken};
-// If you want to try std support, also update the guest Cargo.toml file
+// If you want to try std support, also update the guests Cargo.toml file
 use risc0_zkvm::guest::env;
 use serde::{Deserialize, Serialize};
 
 risc0_zkvm::guest::entry!(main);
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct GenericCredential {
+    #[serde(rename = "credentialSubject")]
+    credential_subject: serde_json::Value, // Flexible subject
+    issuer: Issuer,
+    #[serde(rename = "type")]
+    types: Vec<String>,
+    #[serde(rename = "@context")]
+    context: Vec<String>,
+    #[serde(rename = "issuanceDate")]
+    issuance_date: String,
+    proof: Proof,
+}
+
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct PersonCredentialSubject {

--- a/methods/guests/predicate_verifier/Cargo.toml
+++ b/methods/guests/predicate_verifier/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jwt_verify"
+name = "predicate_verifier"
 version = "0.1.0"
 edition = "2021"
 

--- a/methods/guests/predicate_verifier/src/main.rs
+++ b/methods/guests/predicate_verifier/src/main.rs
@@ -1,0 +1,110 @@
+#![no_main]
+
+use ed25519_dalek::VerifyingKey;
+use jwt_compact::{alg::*, prelude::*, Token, UntrustedToken};
+// If you want to try std support, also update the guests Cargo.toml file
+use risc0_zkvm::guest::env;
+use serde::{Deserialize, Serialize};
+
+risc0_zkvm::guest::entry!(main);
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct GenericCredential {
+    #[serde(rename = "credentialSubject")]
+    credential_subject: serde_json::Value,
+    // Flexible subject
+    issuer: Issuer,
+    #[serde(rename = "type")]
+    types: Vec<String>,
+    #[serde(rename = "@context")]
+    context: Vec<String>,
+    #[serde(rename = "issuanceDate")]
+    issuance_date: String,
+    proof: Proof,
+}
+
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Issuer {
+    id: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Proof {
+    #[serde(rename = "type")]
+    proof_type: String,
+    jwt: String,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct CredentialClaims {
+    vc: CredentialSubjectClaims,
+    sub: String,
+    iss: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct CredentialSubjectClaims {
+    #[serde(rename = "credentialSubject")]
+    credential_subject: serde_json::Value,
+    #[serde(rename = "type")]
+    types: Vec<String>,
+    #[serde(rename = "@context")]
+    context: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+enum Condition {
+    LT,
+    GT,
+    EQ,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Predicate {
+    field: String,
+    condition: Condition,
+    value: u32,
+}
+
+fn check_predicate(claims: &CredentialClaims, predicate: &Predicate) -> bool {
+    let credential_subject = &claims.vc.credential_subject;
+    let field = &predicate.field;
+    let value = &predicate.value;
+    let condition = &predicate.condition;
+    let credential_subject = credential_subject[field].as_u64().unwrap() as u32;
+    match condition {
+        Condition::LT => credential_subject < *value,
+        Condition::GT => credential_subject > *value,
+        Condition::EQ => credential_subject == *value,
+    }
+}
+
+pub fn main() {
+    let (jwt_credential, public_key_issuer, predicate): (String, String, Predicate) = env::read();
+
+    let bytes_pk_eid_issuer: &[u8; 32] = &hex::decode(&public_key_issuer).unwrap().try_into().unwrap();
+
+    // Verify the signature, panicking if verification fails.
+    let verifying_key_eid_issuer = VerifyingKey::from_bytes(&bytes_pk_eid_issuer).unwrap();
+
+    let untrusted_token_credential = UntrustedToken::new(&jwt_credential).unwrap();
+
+    let credential_claims: Token<CredentialClaims> = Ed25519.validator(&verifying_key_eid_issuer).validate(&untrusted_token_credential).unwrap();
+    let credential = &credential_claims.claims().custom;
+
+    let date_of_birth = credential.vc.credential_subject["date_of_birth"].as_u64().unwrap() as u32;
+    let predicate_date_of_birth = predicate.value;
+    let predicate_condition = &predicate.condition;
+    let predicate_field = &predicate.field;
+
+    println!("date_of_birth: {}", date_of_birth);
+    println!("predicate_date_of_birth: {}", predicate_date_of_birth);
+    println!("predicate_condition: {:?}", predicate_condition);
+    println!("predicate_field: {}", predicate_field);
+
+    let is_valid = check_predicate(credential, &predicate);
+
+    // Commit to the journal the verifying key and message that was signed.
+    env::commit(&(is_valid));
+}

--- a/methods/guests/predicate_verifier/src/main.rs
+++ b/methods/guests/predicate_verifier/src/main.rs
@@ -98,11 +98,6 @@ pub fn main() {
     let predicate_condition = &predicate.condition;
     let predicate_field = &predicate.field;
 
-    println!("date_of_birth: {}", date_of_birth);
-    println!("predicate_date_of_birth: {}", predicate_date_of_birth);
-    println!("predicate_condition: {:?}", predicate_condition);
-    println!("predicate_field: {}", predicate_field);
-
     let is_valid = check_predicate(credential, &predicate);
 
     // Commit to the journal the verifying key and message that was signed.


### PR DESCRIPTION
This PR let us query the Credential and decide what the guest code shall return if the query meet it's conditions.

So by having this Credential(only show the `credentialSubject` to not make it bloated):

```json
    "credentialSubject": {
      "name": "Bob Bobley",
      "date_of_birth": 19801001,
      "nationality": "NO",
      "id": "did:key:z6Mkn8ji3BqfuiDdcSQ9PXgnZEB1DWoEY19YX3hHNkYxcc1h"
    },
```

And this predicate:
```rust
    let predicate = Predicate{
        field: String::from("date_of_birth"),
        condition: GT,
        value: 19791001,
        return_value: String::from("Subject is older than 40 years old")
    };
```

We can pass this result to a verifier.

This is just a poc, but to make this work we also need to return the did of the issuer and the query result in a way that make sense for someone looking at the data.

Closes #2 